### PR TITLE
feat: 쿠키를 thread local 로 관리하고, feign client 요청 시 header 에 token 을 담음

### DIFF
--- a/src/main/java/com/nhnacademy/store99/front/auth/adapter/AuthAdaptor.java
+++ b/src/main/java/com/nhnacademy/store99/front/auth/adapter/AuthAdaptor.java
@@ -5,7 +5,6 @@ import com.nhnacademy.store99.front.common.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
  * 관리자 권한 체크 어댑터
@@ -16,5 +15,5 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @FeignClient(value = "store99-gateway-service", url = "${gateway.url}/api/bookstore/v1/admin", decode404 = true)
 public interface AuthAdaptor {
     @GetMapping("/check")
-    ResponseEntity<CommonResponse<AdminCheckResponse>> checkAdmin(@RequestHeader("X-USER-TOKEN") String xUserToken);
+    ResponseEntity<CommonResponse<AdminCheckResponse>> checkAdmin();
 }

--- a/src/main/java/com/nhnacademy/store99/front/auth/exception/LoginRequiredException.java
+++ b/src/main/java/com/nhnacademy/store99/front/auth/exception/LoginRequiredException.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.store99.front.auth.exception;
+
+public class LoginRequiredException extends RuntimeException {
+    public LoginRequiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nhnacademy/store99/front/auth/service/impl/AdminCheckServiceImpl.java
+++ b/src/main/java/com/nhnacademy/store99/front/auth/service/impl/AdminCheckServiceImpl.java
@@ -4,7 +4,6 @@ import com.nhnacademy.store99.front.auth.adapter.AuthAdaptor;
 import com.nhnacademy.store99.front.auth.dto.response.AdminCheckResponse;
 import com.nhnacademy.store99.front.auth.service.AdminCheckService;
 import com.nhnacademy.store99.front.common.response.CommonResponse;
-import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +27,7 @@ public class AdminCheckServiceImpl implements AdminCheckService {
     @Override
     public Boolean checkAdmin() {
         CommonResponse<AdminCheckResponse> response =
-                authAdaptor.checkAdmin(XUserTokenThreadLocal.getXUserToken()).getBody();
+                authAdaptor.checkAdmin().getBody();
         assert response != null;
         if (!response.getHeader().isSuccessful()) {
             return false;

--- a/src/main/java/com/nhnacademy/store99/front/common/advice/CommonControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/advice/CommonControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.store99.front.common.advice;
 
+import com.nhnacademy.store99.front.auth.exception.LoginRequiredException;
 import feign.FeignException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,6 +24,14 @@ public class CommonControllerAdvice {
     public ModelAndView unauthorizedExceptionHandler(FeignException.Unauthorized ex) {
         ModelAndView mv = new ModelAndView();
         mv.setViewName("error/unauthorized");
+
+        return mv;
+    }
+
+    @ExceptionHandler(value = {LoginRequiredException.class})
+    public ModelAndView loginRequiredException(LoginRequiredException ex) {
+        ModelAndView mv = new ModelAndView();
+        mv.setViewName("login_form");
 
         return mv;
     }

--- a/src/main/java/com/nhnacademy/store99/front/common/interceptor/CookieAddInThreadLocalInterceptor.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/interceptor/CookieAddInThreadLocalInterceptor.java
@@ -1,0 +1,38 @@
+package com.nhnacademy.store99.front.common.interceptor;
+
+import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
+import com.nhnacademy.store99.front.common.util.CookieUtils;
+import java.util.Objects;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * /books, /mypage, 등의 요청 시에 X-USER-TOKEN cookie 를 thread local 에 저장 하는 interceptor
+ *
+ * @author Ahyeon Song
+ */
+public class CookieAddInThreadLocalInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        Cookie xUserTokenCookie = CookieUtils.getCookie(request, "X-USER-TOKEN");
+
+        if (Objects.isNull(xUserTokenCookie)){
+            response.sendRedirect("/error/bad_request");
+            return false;
+        }
+
+        XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());
+
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+                           ModelAndView modelAndView) throws Exception {
+        XUserTokenThreadLocal.reset();
+    }
+}

--- a/src/main/java/com/nhnacademy/store99/front/common/interceptor/XUserTokenCheckForUserInterceptor.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/interceptor/XUserTokenCheckForUserInterceptor.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.store99.front.common.interceptor;
 
+import com.nhnacademy.store99.front.auth.exception.LoginRequiredException;
 import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
 import com.nhnacademy.store99.front.common.util.CookieUtils;
 import java.util.Objects;
@@ -14,15 +15,14 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author Ahyeon Song
  */
-public class CookieAddInThreadLocalInterceptor implements HandlerInterceptor {
+public class XUserTokenCheckForUserInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
         Cookie xUserTokenCookie = CookieUtils.getCookie(request, "X-USER-TOKEN");
 
-        if (Objects.isNull(xUserTokenCookie)){
-            response.sendRedirect("/error/bad_request");
-            return false;
+        if (Objects.isNull(xUserTokenCookie)) {
+            throw new LoginRequiredException("X-USER-TOKEN 쿠키 없음, 로그인 필요");
         }
 
         XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());

--- a/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
@@ -23,7 +23,7 @@ public class FeignConfig {
     public RequestInterceptor requestInterceptor() {
         return template -> {
             String url = template.url();
-            if (url.startsWith(gatewayUrl + "/api/bookstore") || url.startsWith(gatewayUrl + "/api/coupon")) {
+            if (url.startsWith(gatewayUrl + "/api")) {
                 String xUserToken = getXUserToken();
                 template.header("X-USER-TOKEN", xUserToken);
             }

--- a/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
@@ -1,0 +1,36 @@
+package com.nhnacademy.store99.front.config;
+
+import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Ahyeon Song
+ */
+@Configuration
+public class FeignConfig {
+
+    @Value("${gateway.url}")
+    private String gatewayUrl;
+
+    /**
+     * feign client 동작 시에 thread local 에서 쿠키를 가져와 header 에 담는 메소드
+     * @return
+     */
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> {
+            String url = template.url();
+            if (url.startsWith(gatewayUrl + "/api/bookstore") || url.startsWith(gatewayUrl + "/api/coupon")) {
+                String xUserToken = getXUserToken();
+                template.header("X-USER-TOKEN", xUserToken);
+            }
+        };
+    }
+
+    private String getXUserToken() {
+        return XUserTokenThreadLocal.getXUserToken();
+    }
+}

--- a/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/FeignConfig.java
@@ -1,7 +1,9 @@
 package com.nhnacademy.store99.front.config;
 
 import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
+import feign.Logger;
 import feign.RequestInterceptor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,19 +12,24 @@ import org.springframework.context.annotation.Configuration;
  * @author Ahyeon Song
  */
 @Configuration
+@Slf4j
 public class FeignConfig {
 
     @Value("${gateway.url}")
     private String gatewayUrl;
 
     /**
+     * feign client 공통 헤더 추가
      * feign client 동작 시에 thread local 에서 쿠키를 가져와 header 에 담는 메소드
+     *
      * @return
      */
     @Bean
     public RequestInterceptor requestInterceptor() {
+        log.debug("request interceptor 동작");
         return template -> {
-            String url = template.url();
+            String url = template.feignTarget().url();
+            log.debug("url : {}", url);
             if (url.startsWith(gatewayUrl + "/api")) {
                 String xUserToken = getXUserToken();
                 template.header("X-USER-TOKEN", xUserToken);
@@ -33,4 +40,36 @@ public class FeignConfig {
     private String getXUserToken() {
         return XUserTokenThreadLocal.getXUserToken();
     }
+
+    /**
+     *
+     * @return
+     */
+//    @Bean
+//    public Decoder decoder() {
+//        return new Decoder() {
+//            private final ObjectMapper objectMapper = new ObjectMapper();
+//
+//            @Override
+//            public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {
+//
+//                String body = Util.toString(response.body().asReader());
+//                JavaType javaType = objectMapper.getTypeFactory()
+//                        .constructParametricType(CommonResponse.class, TypeFactory.rawClass(type));
+//
+//                CommonResponse<?> commonResponse = objectMapper.readValue(body, javaType);
+//                return commonResponse.getResult();
+//            }
+//        };
+//    }
+
+    /**
+     * Feign Client 의 custom logger
+     * FULL : header, body, metadata, request, response 를 표시
+     */
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+
 }

--- a/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.store99.front.config;
 
-import com.nhnacademy.store99.front.common.interceptor.CookieAddInThreadLocalInterceptor;
+import com.nhnacademy.store99.front.common.interceptor.XUserTokenCheckForUserInterceptor;
 import com.nhnacademy.store99.front.common.interceptor.XUserTokenCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -18,6 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new XUserTokenCheckInterceptor()).addPathPatterns("/admin/**")
                 .excludePathPatterns("/admin/error/forbidden");
-        registry.addInterceptor(new CookieAddInThreadLocalInterceptor()).addPathPatterns("/books/**", "/mypage/**, /logout");
+        registry.addInterceptor(new XUserTokenCheckForUserInterceptor())
+                .addPathPatterns("/books/**", "/mypage/**, /logout");
     }
 }

--- a/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.store99.front.config;
 
+import com.nhnacademy.store99.front.common.interceptor.CookieAddInThreadLocalInterceptor;
 import com.nhnacademy.store99.front.common.interceptor.XUserTokenCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,6 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * WebMvcConfigurer 설정
  *
  * @author seunggyu-kim
+ * @author Ahyeon Song
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -16,5 +18,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new XUserTokenCheckInterceptor()).addPathPatterns("/admin/**")
                 .excludePathPatterns("/admin/error/forbidden");
+        registry.addInterceptor(new CookieAddInThreadLocalInterceptor()).addPathPatterns("/books/**", "/mypage/**, /logout");
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,3 +8,5 @@ gateway.url=http://localhost:8760
 # Live Reload
 spring.devtools.livereload.enabled=true
 spring.devtools.restart.enabled=true
+# Feign Client logger
+logging.level.feign.Logger=DEBUG

--- a/src/main/resources/templates/error/bad_request.html
+++ b/src/main/resources/templates/error/bad_request.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+Bad Request
+</body>
+</html>

--- a/src/main/resources/templates/sign-up.html
+++ b/src/main/resources/templates/sign-up.html
@@ -140,7 +140,8 @@
                                         <div class="form-group">
                                             <label for="emailConfirmationCode">이메일 인증번호</label>
                                             <div class="input-group mb-3">
-                                                <input class="form-control" id="emailConfirmationCode" placeholder="인증번호 입력"
+                                                <input class="form-control" id="emailConfirmationCode"
+                                                       placeholder="인증번호 입력"
                                                        required type="text">
                                                 <div class="input-group-append" style="margin-left : 15px">
                                                     <button class="btn btn-primary" id="checkEmail" type="button">인증하기


### PR DESCRIPTION
# Cookie 직접 전달 -> Header 에 담아 전달

- front 의 fegin client 에서 쿠키를 직접 전달 할 수 없음에 따라, 쿠키를 thread local 로 관리하고, FeignConfig의 interceptor 가 feign client 동작 시에 이를 header 에 담습니다.
-  그러므로 /api 경로의 feign client 호출 시에는 파라미터에 `@RequestHeader("X-USER-TOKEN")` 을 포함하여야 합니다.

<br>

## 변경 사항
- CookieAddInThreadLocalInterceptor : webConfig 의 `registry.addInterceptor(new CookieAddInThreadLocalInterceptor()).addPathPatterns("/books/**", "/mypage/**, /logout");` 에 따라 해당 요청 시에 Cookie 가 ThreadLocal 에 추가됩니다.
- FeignConfig : /api 경로의 feign client 요청일 경우 ThreadLocal 의 `X-USER-TOKEN` 을 header 에 담습니다. (이름 동일)

