### PR TITLE
Feat : 로그인 체크 중 인증 및 토큰 관련 오류 발생 시 쿠키 제거 후 기존 요청으로 이동

### DIFF
--- a/src/main/java/com/nhnacademy/store99/front/common/interceptor/LoginStatusCheckInterceptor.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/interceptor/LoginStatusCheckInterceptor.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 /**
  * 모든 Controller 실행 전에 Cookie 유무를 확인하고 로그인 상태를 판단하는 Interceptor
@@ -32,11 +31,12 @@ public class LoginStatusCheckInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
+        log.debug("LoginStatusCheckInterceptor > preHandle > request.getRequestURI() 요청 주소: {}",
+                request.getRequestURI());
         Cookie xUserTokenCookie = CookieUtils.getCookie(request, "X-USER-TOKEN");
 
         if (Objects.nonNull(xUserTokenCookie)) {
             log.debug("X-USER-TOKEN Cookie : {}", xUserTokenCookie);
-            XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());
 
             Boolean isAdmin;
             try {
@@ -60,20 +60,21 @@ public class LoginStatusCheckInterceptor implements HandlerInterceptor {
                 request.setAttribute("isAdmin", true);
             }
 
+            XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());
         } else {
             log.debug("로그아웃 상태 : X-USER-TOKEN Cookie 가 존재하지 않음");
             request.setAttribute("isLogin", false);
             request.setAttribute("isAdmin", false);
         }
 
+
         return HandlerInterceptor.super.preHandle(request, response, handler);
     }
 
     @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-                           ModelAndView modelAndView) throws Exception {
+    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
+                                final Object handler, final Exception ex)
+            throws Exception {
         XUserTokenThreadLocal.reset();
-
-        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
     }
 }

--- a/src/main/java/com/nhnacademy/store99/front/common/interceptor/LoginStatusCheckInterceptor.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/interceptor/LoginStatusCheckInterceptor.java
@@ -1,6 +1,5 @@
 package com.nhnacademy.store99.front.common.interceptor;
 
-import com.nhnacademy.store99.front.auth.exception.LoginCheckException;
 import com.nhnacademy.store99.front.auth.service.AdminCheckService;
 import com.nhnacademy.store99.front.common.thread_local.XUserTokenThreadLocal;
 import com.nhnacademy.store99.front.common.util.CookieUtils;
@@ -37,15 +36,26 @@ public class LoginStatusCheckInterceptor implements HandlerInterceptor {
 
         if (Objects.nonNull(xUserTokenCookie)) {
             log.debug("X-USER-TOKEN Cookie : {}", xUserTokenCookie);
+            XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());
 
-            Boolean isAdmin;
+            boolean isAdmin;
             try {
                 isAdmin = adminCheckService.checkAdmin();
 
-            } catch (FeignException.Unauthorized ex) {
-                log.debug("로그인 상태 확인 에러 : 토큰은 존재하나 Gateway 에서 401 Error 받음 (Token 문제)");
+            } catch (FeignException.BadRequest | FeignException.Unauthorized ex) {
+                log.debug("로그인 상태 확인 에러 : 토큰은 존재하나 Gateway 에서 {} Error 받음 (Token 문제)", ex.status());
                 request.setAttribute("isLogin", false);
-                throw new LoginCheckException("로그인 상태 확인 불가");
+
+                CookieUtils.deleteCookie(request, response, "X-USER-TOKEN");
+                log.debug("사용 불가능한 X-USER-TOKEN Cookie 삭제");
+
+                XUserTokenThreadLocal.reset();
+                log.debug("사용 불가능한 X-USER-TOKEN ThreadLocal 삭제");
+
+                request.setAttribute("isLogin", false);
+                request.setAttribute("isAdmin", false);
+
+                return HandlerInterceptor.super.preHandle(request, response, handler);
             }
 
             log.debug("로그인 상태 확인 성공");
@@ -60,7 +70,6 @@ public class LoginStatusCheckInterceptor implements HandlerInterceptor {
                 request.setAttribute("isAdmin", true);
             }
 
-            XUserTokenThreadLocal.setXUserToken(xUserTokenCookie.getValue());
         } else {
             log.debug("로그아웃 상태 : X-USER-TOKEN Cookie 가 존재하지 않음");
             request.setAttribute("isLogin", false);

--- a/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
+++ b/src/main/java/com/nhnacademy/store99/front/config/WebConfig.java
@@ -23,8 +23,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(loginStatusCheckInterceptor())
-                .addPathPatterns("/**").order(1);
+        registry.addInterceptor(loginStatusCheckInterceptor()).excludePathPatterns("/error", "/static/**", "/assets/**")
+                .order(1);
 //        registry.addInterceptor(new XUserTokenCheckForAdminInterceptor()).addPathPatterns("/admin/**").order(2);
 //        registry.addInterceptor(new XUserTokenCheckForUserInterceptor())
 //                .addPathPatterns("/mypage/**")


### PR DESCRIPTION
# 이슈
LoginCheckInterceptor 에서 gateway 를 통해 권한 체크를 하는 중 `JWT Token 만료`나 `올바르지 않은 서명` 같은 에러 발생 시 500 ERROR 가 Front 까지 전해졌습니다. 이로 인해, 기존의 요청까지 가지 못하고, 훼손된 토큰이 계속 존재하여, 어떠한 요청을 해도 500 ERROR 가 계속해서 발생했습니다.

- https://github.com/nhnacademy-be5-staff99/store99-gateway/issues/23

# 해결
JWT Token 만료 및 올바르지 않은 서명에 대해 Gateway 에서 401 Error 를 반환하게 하였고, Front 는 이를 받으면 훼손되었다고 간주되는 `X-USER-TOKEN 을 Cookie 에서 삭제 & Thread Local 에서 삭제`합니다. 
또한, 기존에 로그인 체크 도중 오류 발생 시 index page 로 redirect 되던 로직을, Throw Exception 을 삭제하여 Cookie 삭제 작업 후 `원래 요청했던 곳으로 갈 수 있도록` 변경했습니다.

# 결론
이로써 로그인 체크 중 오류가 발생하면 `X-USER-TOKEN Cookie 가 삭제된 상태로 기존 요청으로 이동`합니다.
만약, X-USER-TOKEN 이 필요한 요청이었을 경우, 해당 요청에서도 Gateway 를 갈 때 권한 체크를 하므로 그곳에서 관련 에러를 처리할 것입니다.

# 테스트 방식
1. 로그인을 한다
2. 장바구니로 이동한다
3. 장바구니 페이지에서 Cookie 를 훼손시킨다
4. 장바구니 페이지를 새로고침한다
5. Cookie 는 삭제되었지만, 장바구니 페이지에 그대로 있는다.