### PR TITLE
feat: 마이페이지에 회원 주소 조회 모달 창 추가

### DIFF
--- a/src/main/java/com/nhnacademy/store99/front/address/adapter/AddressAdapter.java
+++ b/src/main/java/com/nhnacademy/store99/front/address/adapter/AddressAdapter.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.store99.front.address.adapter;
+
+import com.nhnacademy.store99.front.address.dto.AddressMyPageResponse;
+import com.nhnacademy.store99.front.common.response.CommonResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "addressAdapter", url = "${gateway.url}/api/bookstore/v1/address")
+public interface AddressAdapter {
+
+    @GetMapping
+    CommonResponse<List<AddressMyPageResponse>> getUserAddresses();
+}

--- a/src/main/java/com/nhnacademy/store99/front/address/controller/AddressMyPageController.java
+++ b/src/main/java/com/nhnacademy/store99/front/address/controller/AddressMyPageController.java
@@ -1,0 +1,33 @@
+package com.nhnacademy.store99.front.address.controller;
+
+import com.nhnacademy.store99.front.address.dto.AddressMyPageResponse;
+import com.nhnacademy.store99.front.address.service.AddressMyPageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * 마이페이지에서 회원의 주소를 조회하고 관리하기 위한 컨트롤러
+ *
+ * @author Ahyeon Song
+ */
+@Controller
+@RequiredArgsConstructor
+public class AddressMyPageController {
+
+    private final AddressMyPageService addressMyPageService;
+
+    /**
+     * 회원의 주소 리스트를 보여주기 위한 메소드
+     *
+     * @return AddressMyPageResponse
+     */
+    @GetMapping(value = "/my_address_info", produces = "application/json")
+    @ResponseBody
+    public List<AddressMyPageResponse> getMyAddressInfo() {
+        return addressMyPageService.getUserAddresses();
+    }
+
+}

--- a/src/main/java/com/nhnacademy/store99/front/address/dto/AddressMyPageResponse.java
+++ b/src/main/java/com/nhnacademy/store99/front/address/dto/AddressMyPageResponse.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.store99.front.address.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 마이페이지에서 회원의 주소 리스트를 보여주기 위한 형식
+ *
+ * @author Ahyeon Song
+ */
+@Getter
+@AllArgsConstructor
+public class AddressMyPageResponse {
+    private Long addressId;
+    private String addressGeneral;
+    private String addressDetail;
+    private String addressAlias;
+    private Integer addressCode;
+    private Boolean isDefaultAddress;
+}

--- a/src/main/java/com/nhnacademy/store99/front/address/service/AddressMyPageService.java
+++ b/src/main/java/com/nhnacademy/store99/front/address/service/AddressMyPageService.java
@@ -1,0 +1,40 @@
+package com.nhnacademy.store99.front.address.service;
+
+import com.nhnacademy.store99.front.address.adapter.AddressAdapter;
+import com.nhnacademy.store99.front.address.dto.AddressMyPageResponse;
+import com.nhnacademy.store99.front.auth.exception.LoginRequiredException;
+import com.nhnacademy.store99.front.common.response.CommonResponse;
+import feign.FeignException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원의 주소를 조회하고 관리
+ *
+ * @author Ahyeon Song
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AddressMyPageService {
+
+    private final AddressAdapter addressAdapter;
+
+    /**
+     * 마이페이지에서 보여주는 회원의 주소 목록을 반환
+     *
+     * @return AddressMyPageResponse
+     */
+    public List<AddressMyPageResponse> getUserAddresses() {
+        CommonResponse<List<AddressMyPageResponse>> addressResponse;
+        try {
+            addressResponse = addressAdapter.getUserAddresses();
+        } catch (FeignException.Unauthorized | FeignException.BadRequest ex) {
+            throw new LoginRequiredException("고객이 주소를 요청했으나, 로그인 되어있지 않음");
+        }
+
+        return addressResponse.getResult();
+    }
+}

--- a/src/main/java/com/nhnacademy/store99/front/common/advice/CommonControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/store99/front/common/advice/CommonControllerAdvice.java
@@ -69,7 +69,7 @@ public class CommonControllerAdvice {
     @ExceptionHandler(value = {LoginCheckException.class})
     public ModelAndView loginCheckFailException(LoginCheckException ex) {
         ModelAndView mv = new ModelAndView();
-        mv.setViewName("login_form");
+        mv.setViewName("index");
 
         return mv;
     }

--- a/src/main/java/com/nhnacademy/store99/front/mypage/service/MainMyPageService.java
+++ b/src/main/java/com/nhnacademy/store99/front/mypage/service/MainMyPageService.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.store99.front.mypage.service;
 
-import com.nhnacademy.store99.front.auth.exception.LoginCheckException;
+import com.nhnacademy.store99.front.auth.exception.LoginRequiredException;
 import com.nhnacademy.store99.front.common.response.CommonResponse;
 import com.nhnacademy.store99.front.mypage.adapter.MyPageAdapter;
 import com.nhnacademy.store99.front.mypage.dto.MainMyPageResponse;
@@ -29,7 +29,7 @@ public class MainMyPageService {
         try {
             mainMyPageResponse = myPageAdapter.getMainMyPage();
         } catch (FeignException.Unauthorized | FeignException.BadRequest ex) {
-            throw new LoginCheckException("마이페이지에 접근하나, 로그인이 되어있지 않음");
+            throw new LoginRequiredException("마이페이지에 접근하나, 로그인이 되어있지 않음");
         }
         return mainMyPageResponse.getResult();
     }

--- a/src/main/resources/templates/book/book_sales_list.html
+++ b/src/main/resources/templates/book/book_sales_list.html
@@ -30,7 +30,8 @@
                         <ol class="breadcrumb p-3 bg-body-tertiary rounded-3">
                             <li class="breadcrumb-item"
                                 th:classappend="${status.last} ? 'active'"
-                                th:each="category, status: ${categoryChildrenListAndRoute.getNowCategoryRoute()}" th:object="${category}">
+                                th:each="category, status: ${categoryChildrenListAndRoute.getNowCategoryRoute()}"
+                                th:object="${category}">
                                 <a th:href="@{'/categories/{id}/books'(id=*{id})}" th:text="*{categoryName}">Home</a>
                             </li>
                         </ol>

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -10,6 +10,9 @@
 
 
 <div layout:fragment="content">
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
     <main id="main">
         <section class="contact mb-5" id="contact">
             <div class="container" data-aos="fade-up">
@@ -23,7 +26,8 @@
                 <!-- ======= New Layout Start ======= -->
                 <div class="d-flex align-items-start mx-3 row g-5">
                     <!-- ======= Sidebar Start ======= -->
-                    <div class="d-flex flex-column flex-shrink-0 p-3 bg-light col-lg-3 col-md-auto" style="width: 230px;">
+                    <div class="d-flex flex-column flex-shrink-0 p-3 bg-light col-lg-3 col-md-auto"
+                         style="width: 230px;">
                         <a class="d-flex align-items-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none"
                            href="/">
                             <span class="fs-4">Sidebar</span>
@@ -97,14 +101,88 @@
                                 <div class="row">
                                     <div style="display: flex; align-items: center;">
                                         <div class="col-md-2 fs-5">기본 주소</div>
-                                        <a href="/my_address_info"><i class="fas fa-sm fa-chevron-right"
-                                                                      title="user_info_edit"></i></a>
+                                        <!-- Address Modal Trigger Button -->
+                                        <div class="address_modal_btn" data-bs-target="#address_modal"
+                                             data-bs-toggle="modal">
+                                            <i class="fas fa-sm fa-chevron-right" style="cursor: pointer"
+                                               title="user_address_info"></i>
+                                        </div>
                                     </div>
 
                                     <div class="col-md-12 fs-5 mt-2"><p
                                             th:text="${myPageInfo.userAddress.addressAlias} + ' | ' + ${myPageInfo.userAddress.addressGeneral} +  ' ' + ${myPageInfo.userAddress.addressDetail} + ' | ' +${myPageInfo.userAddress.addressCode}"></p>
                                     </div>
                                 </div>
+
+                                <!-- ======= Address Modal Start ======= -->
+                                <div aria-hidden="true" aria-labelledby="address_modal" class="modal fade"
+                                     id="address_modal"
+                                     tabindex="-1">
+                                    <div class="modal-dialog modal-dialog-scrollable">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title">내 주소</h5>
+                                                <button aria-label="Close" class="btn-close address_modal_close"
+                                                        data-bs-dismiss="modal" type="button"></button>
+                                            </div>
+                                            <div class="modal-body">
+
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button class="btn btn-secondary address_modal_close"
+                                                        data-bs-dismiss="modal"
+                                                        type="button">Close
+                                                </button>
+                                                <button class="btn btn-primary" type="button">주소 추가하기</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <script>
+                                    $(document).ready(function () {
+                                        $('.address_modal_btn').on('click', function () {
+                                            $.ajax({
+                                                url: '/my_address_info',
+                                                type: 'GET',
+                                                dataType: 'json',
+                                                success: function (data) {
+                                                    var modalBody = $('#address_modal .modal-body');
+                                                    modalBody.empty();
+
+                                                    data.forEach(function (address) {
+                                                        if (address.isDefaultAddress) {
+                                                            modalBody.append('<p style="font-weight: bold">기본주소</p>');
+                                                        }
+                                                        modalBody.append('<p>' + address.addressAlias + '</p>');
+                                                        modalBody.append('<p>' + address.addressGeneral + ' ' + address.addressDetail + '</p>');
+                                                        modalBody.append('<p style="display: flex; justify-content: space-between;">우편번호 : ' + address.addressCode + '<button class="btn btn-primary delete-button" data-address-id="' + address.addressId + '">삭제</button></p>');
+                                                        modalBody.append('<hr>');
+                                                    });
+
+                                                    $('#address_modal').modal('show');
+                                                },
+                                                error: function (jqXHR, textStatus, errorThrown, data) {
+                                                    console.error('AJAX request fail');
+                                                }
+                                            });
+                                        });
+
+                                        // 모달 종료 (hide)
+                                        $(document).on('click', '.address_modal_close', function () {
+                                            $('#address_modal').modal('hide');
+                                        });
+
+                                        // 선택한 주소 삭제
+                                        $(document).on('click', '.delete-button', function () {
+                                            var addressId = $(this).data('address-id');
+                                            // addressId 에 해당하는 주소 삭제 로직 작성
+
+                                        });
+                                    });
+                                </script>
+                                <!-- ======= Address Modal End ======= -->
+
                             </div><!-- ======= User Info End ======= -->
 
                             <div class="my-5" id="my_grade_title"></div>
@@ -142,7 +220,7 @@
                                 <div class="col-md-12 fs-5"><p
                                         th:text="'사용 가능 포인트 : ' + ${#numbers.formatInteger(myPageInfo.userPoint, 1, 'COMMA')} + ' p'"></p>
                                 </div>
-                            </div><!-- ======= My Rate End ======= -->
+                            </div><!-- ======= My Point End ======= -->
 
 
                         </div>

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -37,6 +37,9 @@
                             <li class="nav-item">
                                 <a aria-current="page" class="nav-link active" href="#">회원 정보</a>
                             </li>
+                            <li class="nav-item">
+                                <a aria-current="page" class="nav-link active" href="#">주소 관리</a>
+                            </li>
                             <li>
                                 <a class="nav-link link-dark" href="#my_grade_title">나의 등급</a>
                             </li>
@@ -164,6 +167,7 @@
                                                 },
                                                 error: function (jqXHR, textStatus, errorThrown, data) {
                                                     console.error('AJAX request fail');
+                                                    window.alert('주소 정보를 불러오지 못했습니다');
                                                 }
                                             });
                                         });
@@ -176,6 +180,7 @@
                                         // 선택한 주소 삭제
                                         $(document).on('click', '.delete-button', function () {
                                             var addressId = $(this).data('address-id');
+                                            window.alert('죄송합니다! 아직 지원되지 않는 기능입니다');
                                             // addressId 에 해당하는 주소 삭제 로직 작성
 
                                         });


### PR DESCRIPTION
# 마이페이지에서 주소 조회
## `url : /my_address_info`

- [x] 회원 주소 조회

메인 마이페이지에서 `기본 주소 옆 >` 버튼을 누르면 회원 id 와 일치하는 주소 리스트가 모달창으로 뜹니다.
모달창 특성 상 비동기로 가져오기 위해 ajax 를 사용했습니다.

![Image](https://github.com/nhnacademy-be5-staff99/store99-front/assets/114563915/bf573f91-e721-45df-8e9b-774108e59811)


#132
