### PR TITLE
fix: 8차 배포 중 address 버그 수정

### DIFF
--- a/src/main/java/com/nhnacademy/store99/front/address/controller/AddressMyPageController.java
+++ b/src/main/java/com/nhnacademy/store99/front/address/controller/AddressMyPageController.java
@@ -5,6 +5,7 @@ import com.nhnacademy.store99.front.address.dto.UserAddressResponse;
 import com.nhnacademy.store99.front.address.dto.UserAddressUpdateRequest;
 import com.nhnacademy.store99.front.address.dto.UserChangeDefaultAddressRequest;
 import com.nhnacademy.store99.front.address.service.AddressMyPageService;
+import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -58,10 +59,11 @@ public class AddressMyPageController {
     }
 
     @PostMapping("/address/add")
-    public String addUserAddress(@RequestBody UserAddressAddRequest request) {
+    @ResponseBody
+    public ResponseEntity<Void> addUserAddress(@RequestBody UserAddressAddRequest request) {
         addressMyPageService.addUserAddress(request);
 
-        return "redirect:/my_address_view";
+        return ResponseEntity.created(URI.create("address/add")).build();
     }
 
     @PatchMapping("/address/update")

--- a/src/main/resources/static/assets/js/mypage_address.js
+++ b/src/main/resources/static/assets/js/mypage_address.js
@@ -66,7 +66,7 @@ $(document).ready(function () {
 $(document).ready(function () {
     // 수정 버튼에 클릭 이벤트 리스너 추가
     $('.address-update-btn').click(function () {
-        var addressId = $(this).attr('id');
+        var addressId = $(this).data('id');
 
         // 주소 정보 가져오기
         $.ajax({
@@ -75,19 +75,10 @@ $(document).ready(function () {
             success: function (addressInfo) {
                 console.log(addressInfo);
                 // 모달의 입력 필드에 주소 정보 채우기
-                $('#aliasInput').val(addressInfo.addressAlias);
-                $('#postCodeInput').val(addressInfo.addressCode);
-                $('#generalAddressInput').val(addressInfo.addressGeneral);
-                $('#detailAddressInput').val(addressInfo.addressDetail);
-
-                // 모달 header 의 제목 변경
-                $('#addressModalLabel').text('주소 수정');
-
-                // 모달의 footer 에 '추가하기' 버튼 삭제
-                $('#addAddress').remove();
-
-                // 모달의 footer에 '수정하기' 버튼 추가
-                $('.modal-footer').append('<button type="button" class="btn btn-primary" id="updateAddress">수정하기</button>');
+                $('#aliasUpdate').val(addressInfo.addressAlias);
+                $('#postCodeUpdate').val(addressInfo.addressCode);
+                $('#generalAddressUpdate').val(addressInfo.addressGeneral);
+                $('#detailAddressUpdate').val(addressInfo.addressDetail);
 
                 // '수정하기' 버튼에 클릭 이벤트 리스너 추가
                 $('#updateAddress').click(function () {
@@ -108,7 +99,7 @@ $(document).ready(function () {
                         contentType: 'application/json; charset=utf-8',
                         success: function () {
                             // 요청이 성공적으로 완료되면 모달을 닫고 페이지를 새로 고침합니다.
-                            $('#addressModal').modal('hide');
+                            $('#addressUpdateModal').modal('hide');
                             location.reload();
                         },
                         error: function () {
@@ -119,7 +110,9 @@ $(document).ready(function () {
                 });
 
                 // 모달 창 열기
-                $('#addressModal').modal('show');
+                $('#addressUpdateModal').modal('show');
+
+
             },
             error: function () {
                 // 요청이 실패하면 오류 메시지를 표시합니다.
@@ -127,4 +120,20 @@ $(document).ready(function () {
             }
         });
     });
+});
+
+// 주소 추가 모달 창 닫을 때 입력 필드 초기화
+$('#addressModal').on('hidden.bs.modal', function () {
+    $('#aliasInput').val('');
+    $('#postCodeInput').val('');
+    $('#generalAddressInput').val('');
+    $('#detailAddressInput').val('');
+});
+
+// 주소 삭제 모달 창 닫을 때 입력 필드 초기화
+$('#addressUpdateModal').on('hidden.bs.modal', function () {
+    $('#aliasUpdate').val('');
+    $('#postCodeUpdate').val('');
+    $('#generalAddressUpdate').val('');
+    $('#detailAddressUpdate').val('');
 });

--- a/src/main/resources/templates/login_form.html
+++ b/src/main/resources/templates/login_form.html
@@ -63,8 +63,6 @@
                                                     password: password
                                                 },
                                                 success: function (data, textStatus, request) {
-                                                    // 서버로부터 받은 쿠키를 저장
-                                                    document.cookie = request.getResponseHeader('Set-Cookie');
                                                     // index 페이지로 리다이렉트
                                                     window.location.href = request.getResponseHeader('Location');
                                                 },

--- a/src/main/resources/templates/mypage/mypage_address.html
+++ b/src/main/resources/templates/mypage/mypage_address.html
@@ -81,7 +81,8 @@
                             <hr>
 
                             <!-- ======= Address Add Modal Start ======= -->
-                            <div aria-hidden="true" aria-labelledby="addressModalLabel" class="modal fade" id="addressModal"
+                            <div aria-hidden="true" aria-labelledby="addressModalLabel" class="modal fade"
+                                 id="addressModal"
                                  tabindex="-1">
                                 <div class="modal-dialog">
                                     <div class="modal-content">
@@ -95,13 +96,13 @@
                                                    type="text">
                                             <div class="input-group mb-3">
                                                 <input class="form-control" id="postCodeInput" placeholder="우편번호"
-                                                       type="text">
+                                                       readonly type="text">
                                                 <button onclick="sample4_execDaumPostcode()" type="button">주소 찾기
                                                 </button>
                                             </div>
                                             <span id="guide" style="color:#999;display:none"></span>
                                             <input class="form-control" id="generalAddressInput" placeholder="도로명주소"
-                                                   type="text">
+                                                   readonly type="text">
                                             <input class="form-control" id="detailAddressInput" placeholder="상세주소"
                                                    type="text">
                                         </div>
@@ -131,7 +132,9 @@
                                          style="display: flex; justify-content: space-between; align-items: center;">
                                         <p th:text="${userAddress.addressCode}"></p>
                                         <div>
-                                            <button class="btn btn-outline-dark address-update-btn" th:id="${userAddress.addressId}"
+                                            <button class="btn btn-outline-dark address-update-btn" data-bs-target="#addressUpdateModal"
+                                                    data-bs-toggle="modal"
+                                                    th:data-id="${userAddress.addressId}"
                                                     type="button">수정
                                             </button>
                                             <button class="btn btn-outline-dark address-delete-btn"
@@ -149,6 +152,41 @@
                                     <hr>
                                 </th:block>
                             </div><!-- ======= Address List End ======= -->
+
+                            <!-- ======= Address Update Modal Start ======= -->
+                            <div aria-hidden="true" aria-labelledby="addressModalLabel" class="modal fade"
+                                 id="addressUpdateModal"
+                                 tabindex="-1">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="addressUpdateModalLabel">주소 수정</h5>
+                                            <button aria-label="Close" class="btn-close" data-bs-dismiss="modal"
+                                                    type="button"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <input class="my-1 form-control" id="aliasUpdate" placeholder="별칭"
+                                                   type="text">
+                                            <div class="input-group mb-3">
+                                                <input class="form-control" id="postCodeUpdate" placeholder="우편번호"
+                                                       readonly type="text">
+                                                <button onclick="sample4_execDaumPostcode()" type="button">주소 찾기
+                                                </button>
+                                            </div>
+                                            <span id="guide-update" style="color:#999;display:none"></span>
+                                            <input class="form-control" id="generalAddressUpdate" placeholder="도로명주소"
+                                                   readonly type="text">
+                                            <input class="form-control" id="detailAddressUpdate" placeholder="상세주소"
+                                                   type="text">
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">닫기
+                                            </button>
+                                            <button class="btn btn-primary" id="updateAddress" type="button">수정하기</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div><!-- ======= Address Update Modal End ======= -->
                         </div>
                     </div>
                     <!-- ======= Address Info End ======= -->


### PR DESCRIPTION
# 이슈
- [x] 도로명주소, 우편주소를 직접 수정할 수 없도록 변경 -> `readonly` 설정
- [x] 수정하기 모달창에서 닫기를 누르면 다음에 눌렀을 때 수정하기 버튼이 계속 생기는 버그 해결
- [x] 주소 추가에서 추가하기 버튼을 누르면 추가할 수 없다는 alert 창 버그 해결
- [x] 주소 추가 및 수정 중 추가하기/수정하기 버튼을 누르지 않고 모달 창을 닫는 경우 작성했던 입력 내용이 모달창을 다시 열었을 때 그대로 남아있는 버그 해결
<br>

- [x] 로그인 시 `X-USER-TOKEN` 이외에 이름이 없는 null 쿠기가 생성되는 오류 해결 -> javascript 에서 코드 삭제

---
# 해결
### ✅ 주소 추가에서 추가하기 버튼을 누르면 추가할 수 없다는 alert 창 버그
![Image](https://github.com/nhnacademy-be5-staff99/store99-front/assets/114563915/60d74a06-bcc9-48e3-86fa-3e39671718e6)

db 에 새로 추가한 내용을 저장하는 로직 및 새로고침 후 반영되어 보여지도록 하는 부분은 이상이 없었습니다. 하지만 주소를 추가하지 못하였다는 alert 창이 뜨는 문제가 있었습니다. 배포 환경에서 에러 메세지를 확인하니 /my_address_view 를 불러오는 부분에서 https 가 아닌 http 로 요청하여 문제가 발생했다는 내용이 있었습니다. 
기존의 `POST /address/add` 는 모든 로직 수행 후 /my_address_view 로 redirect 하도록 되어있었는데, 리다이렉트 과정에서 내부에서 이 메소드를 부르므로 https 가 아닌 http 로 불러 문제가 발생한 것 같습니다.
`@ResponseBody` 로 변경하여 Response Entity Created 를 반환하도록 했습니다. 그리하여 자바스크립트에서 오류가 난 것으로 인지하지 않고 정상작동하여 alert 창이 뜨지 않을 것으로 기대됩니다.

ps. 로컬 환경에서 정상작동 한 이유는 인텔리제이에서 자동으로 변경해줘서 그런 것 같습니다.

### ✅ 수정하기 모달창에서 닫기를 누르면 다음에 눌렀을 때 수정하기 버튼이 계속 생기는 버그
기존에는 코드 간편화를 위해 추가하기와 수정하기 모달창을 함께 사용했습니다. 그래서 수정하기 클릭 시에는 추가하기 버튼을 삭제하고 수정하기 버튼을 새로 추가하는 로직으로 작성했습니다.
이 문제를 해결하기 위해 추가하기와 수정하기 모달창 코드를 완전히 분리시켜 수정하기 버튼을 추가하는 부분을 삭제했습니다.

### ✅ 주소 추가 및 수정 중 추가하기/수정하기 버튼을 누르지 않고 모달 창을 닫는 경우 작성했던 입력 내용이 모달창을 다시 열었을 때 그대로 남아있는 버그
자바스크립트 특성 상 입력 내용을 반영하지 않고 모달창을 닫으면 그대로 그 내용이 남아있는 것 같습니다.
현재는 모달 창을 닫는 시점에 모든 내용을 초기화하여 다음에 열었을 때 이전의 내용이 남아있지 않게 했습니다.


# 관련 이슈
- https://github.com/nhnacademy-be5-staff99/store99-front/issues/145